### PR TITLE
Added firefox support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     "128": "icon128.png"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
   "content_scripts": [
     {


### PR DESCRIPTION
This was done by by adding the tag `scripts` to `background`, referencing the `background.js` file. This is an MV2 tag, where `service_worker` is MV3, but Firefox support for service workers is as of yet incomplete, and thus necessary. Both Firefox and Chrome support having the incompatible tag in `background` without an error since version 121. Personal testing shows a silent warning, which does not impact functionality.